### PR TITLE
Fix cpplint line-Range referencing

### DIFF
--- a/git-cpp-check
+++ b/git-cpp-check
@@ -69,7 +69,7 @@ for filename, ranges in changed_lines.iteritems():
   sys.stderr = save_stderr
   for linenum, message in _cpplint_file_errors:
     # Sometimes cpplint reports linenum=0 instead of the acutal line.
-    if not linenum or any((linenum in range(r.start, r.start + r.count) for r in ranges)):
+    if any((r.start <= linenum <= r.start + r.count for r in ranges)) or linenum == 0:
       cpplint_error_count += 1
       sys.stderr.write('%s:%s:  %s\n' % (filename, linenum, message))
 

--- a/git-cpp-check
+++ b/git-cpp-check
@@ -68,7 +68,8 @@ for filename, ranges in changed_lines.iteritems():
   cpplint.ProcessFile(filename, 0)
   sys.stderr = save_stderr
   for linenum, message in _cpplint_file_errors:
-    if any((linenum in r for r in ranges)):
+    # Sometimes cpplint reports linenum=0 instead of the acutal line.
+    if not linenum or any((linenum in range(r.start, r.start + r.count) for r in ranges)):
       cpplint_error_count += 1
       sys.stderr.write('%s:%s:  %s\n' % (filename, linenum, message))
 


### PR DESCRIPTION
Git-clang-format returns lists of Range, but a Range is a named tuple, and not a
python range.

Cpplint sometimes returns linenum=0 instead of a valid line number.